### PR TITLE
Add EVMOS token to supported list

### DIFF
--- a/docs/ALL_SUPPORTED_TOKENS.md
+++ b/docs/ALL_SUPPORTED_TOKENS.md
@@ -940,3 +940,4 @@
 - SUNNY
 - VRT
 - XYZ
+- EVMOS


### PR DESCRIPTION
Was reading this list and saw that EVMOS is not supported. Actually though it seems to have been added and works well.