### PR TITLE
fix: Upgrade axios to latest for service workers compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "ar-gql": "^0.0.6",
     "arweave": "^1.10.16",
     "arweave-multihost": "^0.1.0",
-    "axios": "^1.6.0",
+    "axios": "^1.7.2",
     "deep-sort-object": "^1.0.2",
     "lodash": "^4.17.21",
     "pako": "^2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,10 +1051,10 @@ axios@^0.21.1:
   dependencies:
     follow-redirects "^1.10.0"
 
-axios@^1.6.0:
-  version "1.6.8"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
-  integrity sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==
+axios@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
+  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
## Summary

This PR upgrades `axios` to latest version for service workers compatibility. Latest `axios` contains [fetch adapter](https://github.com/axios/axios?tab=readme-ov-file#-fetch-adapter) which is selected automatically if `xhr` and `http` adapters are not available in the build, or not supported by the environment. Fetch adapter makes axios work in the service worker context. This PR was tested with a browser extension's background service worker created using [Plasmo](https://www.plasmo.com/).
