### PR TITLE
fix: Stop sending toTimestamp for all tokens

### DIFF
--- a/src/proxies/cache-proxy.ts
+++ b/src/proxies/cache-proxy.ts
@@ -47,7 +47,7 @@ export default class CacheProxy {
   }): Promise<{ [symbol: string]: PriceDataWithSignature }> {
     const params: any = {
       provider: args.provider,
-      toTimestamp: args.timestamp ?? Date.now()
+      ...(args.timestamp != null ? { toTimestamp: args.timestamp } : {})
     };
 
     if (args.symbols !== undefined) {


### PR DESCRIPTION
Stop sending toTimestamp in API requests
by default for all tokens.
Requests that include toTimestamp bypass
the API cache, leading to increased latency.